### PR TITLE
feat(darkmode): add useDarkMode hook with tests

### DIFF
--- a/__tests__/hooks/useDarkMode.spec.js
+++ b/__tests__/hooks/useDarkMode.spec.js
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useDarkMode from '../../src/hooks/useDarkMode';
+
+describe('useDarkMode', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('dark-mode-active')
+  });
+  it('is callable', () => {
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current).toBeDefined();
+    expect(window.localStorage.getItem('dark-mode-active')).toEqual("false");
+  });
+
+  it('sets dark mode value', () => {
+    renderHook(() => useDarkMode(true));
+    expect(window.localStorage.getItem('dark-mode-active')).toEqual("true");
+  });
+  
+  it('can toggle dark mode value', async () => {
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current[0]).toEqual(false);
+    expect(window.localStorage.getItem('dark-mode-active')).toEqual("false");
+
+    act(() => result.current[1](true));
+    
+    expect(result.current[0]).toEqual(true);
+    expect(window.localStorage.getItem('dark-mode-active')).toEqual("true");
+
+    act(() => result.current[1](false));
+    
+    expect(result.current[0]).toEqual(false);
+    expect(window.localStorage.getItem('dark-mode-active')).toEqual("false");
+  });
+});

--- a/src/hooks/useDarkMode.js
+++ b/src/hooks/useDarkMode.js
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import useLocalStorage from './useLocalStorage';
+
+const useDarkMode = (defaultValue = false, darkModeClassName = 'dark-mode') => {
+  const [darkModeState, setDarkModeState] = useLocalStorage('dark-mode-active', defaultValue);
+
+  const prefersDarkMode = window.matchMedia
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : false;
+
+  const darkModeActive = typeof darkModeState !== 'undefined' ? darkModeState : prefersDarkMode;
+
+  useEffect(() => {
+    const element = window.document.body;
+    if (darkModeActive) {
+      element.classList.add(darkModeClassName);
+    } else {
+      element.classList.remove(darkModeClassName);
+    }
+  }, [darkModeActive]);
+
+  return [darkModeState, setDarkModeState];
+};
+
+export default useDarkMode;

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ export { default as useGeolocation } from './hooks/useGeolocation';
 export { default as useWindowDimensions } from './hooks/useWindowDimensions';
 export { default as useHandleForm } from './hooks/useHandleForm';
 export { default as useErrorBoundary } from './hooks/useErrorBoundary';
+export { default as useDarkMode } from './hooks/useDarkMode';


### PR DESCRIPTION
# Pull Request Template

## Description
Added a useDarkMode hook that utilizes the existing useLocalStorage hook to track users dark mode preferences and keep them for future sessions. It also uses the CSS rule for `(prefers-color-scheme: dark)` to try to detect this preference from the users browser.

Fixes #16 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I added a `useDarkMode.spec.js` file with 3 basic tests
- [x] Test A - Ensures the hook is callable
- [x] Test B - Ensures you can set a default value when calling the hook
- [x] Test C - Ensures you can toggle value when calling the hook

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules